### PR TITLE
Syntax error

### DIFF
--- a/add-currency/add-currency.php
+++ b/add-currency/add-currency.php
@@ -25,5 +25,5 @@ function add_adverts_currency($list) {
         "label"=>"Botswana pula" // currency long name
     );
     
-    return $list
+    return $list;
 }


### PR DESCRIPTION
The lack of ";" was causing php fatal error in WordPress admin.
